### PR TITLE
After audit update

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,6 @@
 var hlthDRS = artifacts.require("./HealthDRS.sol")
+var hlthToken = '0x0' //update before deploy
 
 module.exports = function(deployer) {
-    deployer.deploy(hlthDRS)
+    deployer.deploy(hlthDRS, hlthToken)
 };

--- a/test/HealthDRS-Admin.js
+++ b/test/HealthDRS-Admin.js
@@ -13,8 +13,7 @@ contract('HealthDRS :: Admin', function(accounts) {
 
   beforeEach(async function() {
     this.token = await HealthCashMock.new()
-    this.drs = await HealthDRS.new()
-    await this.drs.setHealthCashToken(this.token.address)
+    this.drs = await HealthDRS.new(this.token.address)
   })
   
   it('should enable the token to be updated by admin', async function() {

--- a/test/HealthDRS-Logging.js
+++ b/test/HealthDRS-Logging.js
@@ -5,12 +5,14 @@ const should = require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should()
 
+var HealthCashMock = artifacts.require('./helpers/HealthCashMock.sol');
 var HealthDRS = artifacts.require("./HealthDRS.sol")
 
 contract('HealthDRS :: Logging', function(accounts) {
 
   beforeEach(async function() {
-    this.drs = await HealthDRS.new()
+    this.token = await HealthCashMock.new()
+    this.drs = await HealthDRS.new(this.token.address)
     this.url = 'https://blogs.scientificamerican.com/observations/consciousness-goes-deeper-than-you-think/'
     let tx = await this.drs.createService(this.url)
     this.service = tx.logs[0].args._service       
@@ -24,6 +26,18 @@ contract('HealthDRS :: Logging', function(accounts) {
     tx.logs[0].args._owner.should.equal(accounts[0]);    
     tx.logs[0].args._from.should.equal(key);        
     tx.logs[0].args._data.should.equal('test log');
+  })
+
+  it('should enable a service owner to log', async function() {
+    let tx = await this.drs.log(this.service, 'test log')
+    tx.logs[0].args._owner.should.equal(accounts[0]);    
+    tx.logs[0].args._from.should.equal(this.service);        
+    tx.logs[0].args._data.should.equal('test log');
+  })
+
+  it('should not enable a non service owner to log', async function() {
+    let tx = await this.drs.log(this.service, 'test log', {from: accounts[1]})
+    tx.logs.length.should.equal(0);
   })
 
   it('should not enable a non-owner to log', async function() {
@@ -74,6 +88,27 @@ contract('HealthDRS :: Logging', function(accounts) {
     tx = await this.drs.createKey(this.service) 
     let key2 = tx.logs[0].args._key
     tx = await this.drs.message(key1, key2, 'init', 'data', {from: accounts[1]})
+    tx.logs.length.should.equal(0)
+  })
+
+  it('should enable a service owner to message', async function() {
+    let tx = await this.drs.createKey(this.service)
+    let key1 = tx.logs[0].args._key
+
+    tx = await this.drs.message(this.service, key1, 'init', 'data')
+    tx.logs[0].args._owner.should.equal(accounts[0]);    
+    tx.logs[0].args._from.should.equal(this.service);        
+    tx.logs[0].args._to.should.equal(key1);
+    tx.logs[0].args._category.should.equal('init');        
+    tx.logs[0].args._data.should.equal('data');
+
+  })
+
+  it('should not enable a non service owner to message', async function() {
+    let tx = await this.drs.createKey(this.service)
+    let key1 = tx.logs[0].args._key
+
+    tx = await this.drs.message(this.service, key1, 'init', 'data', {from: accounts[1]})
     tx.logs.length.should.equal(0)
   })
 

--- a/test/HealthDRS-Manage.js
+++ b/test/HealthDRS-Manage.js
@@ -12,7 +12,8 @@ import isAddress from './helpers/isAddress'
 contract('HealthDRS :: Manage', function(accounts) {
 
   beforeEach(async function() {
-    this.drs = await HealthDRS.new()
+    this.token = await HealthCashMock.new()
+    this.drs = await HealthDRS.new(this.token.address)
     this.url = 'https://blogs.scientificamerican.com/observations/consciousness-goes-deeper-than-you-think/'
     let tx = await this.drs.createService(this.url)
     this.service = tx.logs[0].args._service       

--- a/test/HealthDRS-Share.js
+++ b/test/HealthDRS-Share.js
@@ -5,13 +5,15 @@ const should = require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should()
 
+var HealthCashMock = artifacts.require('./helpers/HealthCashMock.sol');  
 var HealthDRS = artifacts.require("./HealthDRS.sol")
 import isAddress from './helpers/isAddress'
 
 contract('HealthDRS :: Share', function(accounts) {
 
   beforeEach(async function() {
-    this.drs = await HealthDRS.new()
+    this.token = await HealthCashMock.new()
+    this.drs = await HealthDRS.new(this.token.address)
     this.url = 'https://blogs.scientificamerican.com/observations/consciousness-goes-deeper-than-you-think/'    
   })
   

--- a/test/HealthDRS-Token.js
+++ b/test/HealthDRS-Token.js
@@ -13,8 +13,7 @@ contract('HealthDRS :: Token', function(accounts) {
 
   beforeEach(async function() {
     this.token = await HealthCashMock.new()
-    this.drs = await HealthDRS.new()
-    await this.drs.setHealthCashToken(this.token.address)
+    this.drs = await HealthDRS.new(this.token.address)
   })
 
   it('should have a valid address as token contract', async function() {

--- a/test/HealthDRS.js
+++ b/test/HealthDRS.js
@@ -5,13 +5,15 @@ const should = require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should()
 
+var HealthCashMock = artifacts.require('./helpers/HealthCashMock.sol');
 var HealthDRS = artifacts.require("./HealthDRS.sol")
 import isAddress from './helpers/isAddress'
 
 contract('HealthDRS', function(accounts) {
 
   beforeEach(async function() {
-    this.drs = await HealthDRS.new()
+    this.token = await HealthCashMock.new()
+    this.drs = await HealthDRS.new(this.token.address)
     this.url = 'https://blogs.scientificamerican.com/observations/consciousness-goes-deeper-than-you-think/'    
   })
   

--- a/test/Ownable.js
+++ b/test/Ownable.js
@@ -4,12 +4,14 @@ const should = require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should()
 
+var HealthCashMock = artifacts.require('./helpers/HealthCashMock.sol');
 var HealthDRS = artifacts.require("./HealthDRS.sol")
 
 contract('HealthDRS :: Ownable', function(accounts) {
 
   beforeEach(async function() {
-    this.ownable = await HealthDRS.new()
+    this.token = await HealthCashMock.new()
+    this.ownable = await HealthDRS.new(this.token.address)
   })
 
   it('should have an owner', async function() {


### PR DESCRIPTION
Unresolved,​ ​ Critical:​ ​ Unable​ ​ to​ ​ Send​ ​ Data​ ​ Using​ ​ Message​ ​ Function
Explanation
A​ ​ service​ ​ is​ ​ unable​ ​ to​ ​ send​ ​ data​ ​ via​ ​ the​ ​ message​​ ​ function,​ ​ as​ ​ isKeyOwner​​ ​ will​ ​ throw​ ​ an
exception,​ ​ as​ ​ the​ ​ from​ ​ value​ ​ should​ ​ never​ ​ be​ ​ a ​ ​ valid​ ​ key,​ ​ except​ ​ in​ ​ the​ ​ case​ ​ of​ ​ a ​ ​ hash​ ​ collision, due​ ​ to​ ​ this,​ ​ service​ ​ owners​ ​ are​ ​ unable​ ​ to​ ​ send​ ​ messages.

**Resolution: Added pre-check to key so that it will only check if key is owned if the key is valid preventing the exception - while retaining the ownership check.**

Unresolved,​ ​ Critical:​ ​ Unable​ ​ to​ ​ Send​ ​ Data​ ​ Using​ ​ Log​ ​ Function
A​ ​ service​ ​ is​ ​ unable​ ​ to​ ​ send​ ​ data​ ​ via​ ​ the​ ​ the​ ​ log​​ ​ function,​ ​ as​ ​ isKeyOwner​​ ​ will​ ​ throw​ ​ an
exception,​ ​ as​ ​ the​ ​ from​ ​ value​ ​ should​ ​ never​ ​ be​ ​ a ​ ​ valid​ ​ key,​ ​ except​ ​ in​ ​ the​ ​ case​ ​ of​ ​ a ​ ​ hash​ ​ collision, due​ ​ to​ ​ this,​ ​ service​ ​ owners​ ​ are​ ​ unable​ ​ to​ ​ send​ ​ messages.

**Resolution: Added pre-check to key so that it will only check if key is owned if the key is valid preventing the exception - while retaining the ownership check.**

Unresolved,​ ​ High:​ ​ createService​ ​ Function​ ​ is​ ​ Unprotected
Explanation
The​ ​ createService​​ ​ function​ ​ is​ ​ not​ ​ protected,​ ​ and​ ​ costs​ ​ nothing​ ​ to​ ​ execute,​ ​ there​ ​ is​ ​ nothing
to​ ​ stop​ ​ someone​ ​ from​ ​ mass-spamming​ ​ URI's​ ​ into​ ​ this​ ​ and​ ​ locking​ ​ out​ ​ URI's​ ​ that​ ​ may​ ​ need​ ​ to​ ​ be transferred​ ​ to​ ​ someone​ ​ else,​ ​ and​ ​ there​ ​ is​ ​ nothing​ ​ stopping​ ​ someone​ ​ from​ ​ simply​ ​ executing, generating​ ​ URI's,​ ​ then​ ​ throwing​ ​ away​ ​ the​ ​ account.​ ​ ​ As​ ​ the​ ​ service​ ​ key​ ​ is​ ​ a ​ ​ SHA-3​ ​ sum,​ ​ it​ ​ is extremely​ ​ unlikely​ ​ that​ ​ a ​ ​ hash​ ​ collision​ ​ would​ ​ occur,​ ​ but​ ​ it​ ​ would​ ​ be​ ​ good​ ​ practice​ ​ to​ ​ have​ ​ some way​ ​ to​ ​ clean​ ​ up​ ​ this​ ​ data.

**Resolution: The contract is intended for open use by the developer community so needs to be publicly callable. To address the issue of locking out urls - the service id is now calculated using both the url and msg.sender, this will prevent specific urls from becoming unusable.** 


Unresolved,​ ​ Medium:​ ​ Very​ ​ few​ ​ protections​ ​ to​ ​ ensure​ ​ key​ ​ ownership
Example:​ ​ I ​ ​ could​ ​ offer​ ​ to​ ​ sell​ ​ a ​ ​ key,​ ​ setting​ ​ the​ ​ canTrade​​ ​ value​ ​ to​ ​ true,​ ​ at​ ​ which​ ​ point,​ ​ it​ ​ could be​ ​ sold,​ ​ then​ ​ I ​ ​ could​ ​ execute​ ​ tradeKey​​ ​ with​ ​ a ​ ​ prearranged​ ​ trade​ ​ that​ ​ puts​ ​ the​ ​ key​ ​ back​ ​ under my​ ​ control.

Explanation
When​ ​ keys​ ​ are​ ​ transferred,​ ​ they​ ​ should​ ​ be​ ​ locked​ ​ down​ ​ and​ ​ secured.​ ​ ​ Extra​ ​ owners​ ​ removed,​ ​ all valid​ ​ trade/sell​ ​ states​ ​ cleared,​ ​ etc.​ ​ ​ As​ ​ it​ ​ stands,​ ​ it's​ ​ possible​ ​ to​ ​ sell/trade/handle​ ​ keys,​ ​ then​ ​ "take" them​ ​ back​ ​ if​ ​ you're​ ​ fast​ ​ on​ ​ the​ ​ chain​ ​ and/or​ ​ your​ ​ partner​ ​ doesn't​ ​ perform​ ​ due​ ​ diligence.​ ​ ​ It's​ ​ also possible​ ​ to​ ​ set​ ​ up​ ​ a ​ ​ sale​ ​ in​ ​ advance,​ ​ trade​ ​ the​ ​ key,​ ​ then​ ​ purchase​ ​ it​ ​ back​ ​ immediately​ ​ because cancelSalesOffer​​ ​ isn't​ ​ called​ ​ after​ ​ a ​ ​ trade​ ​ is​ ​ complete.​ ​ ​ Again,​ ​ there​ ​ are​ ​ multiple​ ​ paths​ ​ for this,​ ​ and​ ​ the​ ​ full​ ​ flow​ ​ and​ ​ possible​ ​ stops​ ​ need​ ​ to​ ​ be​ ​ mapped​ ​ out. 

Resolution: Before the following changes creating a salesOffer would cancel a tradeOffer and visa-versa so that you could only have one active at any given time; however the format of the trade function was not consistent with the sales functions so that was unclear. To resolve this we have: 


1. **Refactored the trade function, creating a cancelTradeOffer function to make it clear when this is used.** 
2. **Added an additional requirement to canSell and canTrade modifiers, namely that the key must not be shared at all.** 
3. **Added cancelSalesOffer to the createTradeOffer function and to the end of the purchaseKey function.** 
4. **Added cancelTradeOffer to the createSalesOffer function and to the end of the tradeKey function.** 

**This should accomplish the following: Only unshared keys can be sold or traded. There can only be an active sales offer Or an active trade offer - never both. Completing a sale or trade - removes that sale or trade offer.**


Unresolved,​ ​ Medium:​ ​ No​ ​ Fallback​ ​ Function
Explanation
The​ ​ contract​ ​ should​ ​ have​ ​ a ​ ​ fallback​ ​ function,​ ​ even​ ​ if​ ​ it​ ​ contains​ ​ nothing​ ​ more​ ​ than​ ​ a ​ ​ revert() in​ ​ order​ ​ to​ ​ ensure​ ​ ETH​ ​ isn't​ ​ accidentally​ ​ sent​ ​ and​ ​ trapped​ ​ in​ ​ the​ ​ contract.

**Resolution: Fallback function with revert added**

Unresolved,​ ​ Low:​ ​ No​ ​ Self​ ​ Destruct
Explanation
As​ ​ this​ ​ contract​ ​ could​ ​ potentially​ ​ become​ ​ quite​ ​ large​ ​ over​ ​ time​ ​ because​ ​ it​ ​ is​ ​ functionally​ ​ being used​ ​ as​ ​ a ​ ​ database,​ ​ we​ ​ suggest​ ​ considering​ ​ the​ ​ addition​ ​ of​ ​ a ​ ​ self-destruct​ ​ capability​ ​ in​ ​ case​ ​ you

**Resolution: As this contract is intended to be used by multiple service providers - having an ownerOnly self-destruct may preclude third-party use as the contract’s availability would not be guaranteed.** 

File:​ ​ /HealthDRS.sol
L159:​ ​ Consider​ ​ using​ ​ a ​ ​ constructor​ ​ to​ ​ set​ ​ the​ ​ token.​ ​ in​ ​ lieu​ ​ of​ ​ using​ ​ a ​ ​ constructor,​ ​ consider checking​ ​ that​ ​ token​ ​ has​ ​ been​ ​ set​ ​ before​ ​ operating​ ​ on​ ​ it.
**SVH: Constructor has been added that requires standard token.** 

L167:​ ​ Consider​ ​ requiring​ ​ a ​ ​ boolean​ ​ state​ ​ variable​ ​ check​ ​ on​ ​ the​ ​ _token​ ​ passed​ ​ to
setHealthCashToken

L171:​ ​ What​ ​ does​ ​ latestContract​ ​ do?​ ​ Is​ ​ it​ ​ used​ ​ for​ ​ upgrading​ ​ HealthCash?
**SVH: Dapps using this contract can verify if they are using the latest contract.**

L179:​ ​ require​ ​ that​ ​ url​ ​ is​ ​ defined

L179:​ ​ Should​ ​ the​ ​ createService​ ​ function​ ​ be​ ​ publicly​ ​ callable?
**SVH: Yes, this allows individual developers or groups to create data services that can use health cash.** 

L213:​ ​ The​ ​ shareKey​ ​ function​ ​ ads​ ​ the​ ​ new​ ​ account​ ​ to​ ​ the​ ​ owners​ ​ hash​ ​ on​ ​ L219,​ ​ but​ ​ this​ ​ hash does​ ​ not​ ​ get​ ​ pushed​ ​ to​ ​ for​ ​ the​ ​ original​ ​ owner​ ​ during issueKey​ ​ on​ ​ L195.​ ​ Is​ ​ ownership​ ​ intended​ ​ to​ ​ work​ ​ this​ ​ way?

**SVH: Yes. There’s a primary owner on the key, and group of shared owners. You can’t unshare a primary owner, though the primary owner can unshare any shared owners. So there’s a basic primacy established.** 

L232:​ ​ It's​ ​ unclear​ ​ how​ ​ this​ ​ should​ ​ work​ ​ with​ ​ regards​ ​ to​ ​ the​ ​ original​ ​ owner.

**SVH: The original owner can not be unshared or lose ownership, save for trading or selling the key.** 

L297:​ ​ The​ ​ explicit​ ​ input​ ​ of​ ​ a ​ ​ value​ ​ seems​ ​ unnecessary​ ​ here,​ ​ but​ ​ it's​ ​ unclear

**SVH: Removed value, as was superfluous**

L310:​ ​ Should​ ​ the​ ​ purchaseKey​ ​ function​ ​ call​ ​ cancelSalesOffer​ ​ after​ ​ the​ ​ sale​ ​ has​ ​ taken​ ​ place​ ​ in order​ ​ to​ ​ wipe​ ​ the​ ​ salesOffers​ ​ data?

**SVH: purchaseKey now calls cancelSalesOffer once purchase is complete.** 

L315:​ ​ The​ ​ comment​ ​ about​ ​ being​ ​ authorized​ ​ by​ ​ respective​ ​ services​ ​ isn't​ ​ clear​ ​ because​ ​ it​ ​ looks like​ ​ it​ ​ needs​ ​ to​ ​ owner​ ​ to​ ​ authorize,​ ​ rather​ ​ than​ ​ service.

**SVH: It’s true that the key owner must explicitly create a trade or sell offer - however only a service owner can give the key permission to sell or trade. Essentially both the service owner and key owner are needed to enable this process.** 


L317:​ ​ Consider​ ​ using​ ​ the​ ​ modifier​ ​ validKey​ ​ for​ ​ the​ ​ have​ ​ and​ ​ want​ ​ keys
**SVH: Ownskey includes validKey already, validKey added for want key**

L326:​ ​ This​ ​ should​ ​ be​ ​ consistent​ ​ with​ ​ L274,​ ​ using​ ​ the​ ​ same​ ​ null​ ​ bytes32​ ​ value.
**SVH: made consistent as with L274.** 


L332:​ ​ This​ ​ else​ ​ clause​ ​ should​ ​ be​ ​ separated​ ​ into​ ​ it's​ ​ own​ ​ function​ ​ "createTradeOffer"​ ​ to
encapsulate​ ​ the​ ​ behavior.
**SVH: Separated TradeKey into createTradeOffer, cancelTradeOffer, and tradeKey to be consistent with key sales functions.** 


L368:​ ​ Same​ ​ as​ ​ L326,​ ​ it​ ​ should​ ​ be​ ​ consistent​ ​ with​ ​ L274
**SVH: made consistent**

L373:​ ​ Setting​ ​ the​ ​ null​ ​ value​ ​ for​ ​ the​ ​ buyer​ ​ address​ ​ should​ ​ be​ ​ consistent​ ​ with​ ​ L284​ ​ in
cancelSalesOffer
**SVH: made consistent**

L375:​ ​ Should​ ​ the​ ​ canSell​ ​ value​ ​ for​ ​ salesOffers[key]​ ​ also​ ​ be​ ​ set​ ​ to​ ​ false​ ​ to​ ​ match
cancelSalesOffer?
**SVH: canSell value now set to false.** 

L461-465:​ ​ Can​ ​ be​ ​ condensed​ ​ to​ ​ a ​ ​ single​ ​ line​ ​ require.​ ​ Same​ ​ for​ ​ L467-L471
**SVH: fixed and condensed**

L462,​ ​ L468:​ ​ This​ ​ seems​ ​ like​ ​ another​ ​ good​ ​ reason​ ​ to​ ​ separate​ ​ owners​ ​ into​ ​ separate​ ​ key​ ​ and services

L462,​ ​ L481:​ ​ The​ ​ modifier​ ​ in​ ​ isKeyOwner​ ​ uses​ ​ require​ ​ and​ ​ will​ ​ throw​ ​ an​ ​ exception​ ​ before
isServiceOwner​ ​ can​ ​ be​ ​ called

**SVH: fixed by first qualifying they key as valid before calling for isKeyOwner, this will prevent it from throwing the exception - returning false if they key is not owned (but valid).** 
