### PR TITLE
Update HealthDRS.sol: Change required Solidity version to be ">="

### DIFF
--- a/contracts/HealthDRS.sol
+++ b/contracts/HealthDRS.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity >= 0.4.15;
 
 import 'zeppelin-solidity/contracts/ownership/Ownable.sol';
 import 'zeppelin-solidity/contracts/token/StandardToken.sol';


### PR DESCRIPTION
To prevent conflicts with later versions of solidity. The required version is updated to be "more-than-or-equal" instead of the exact version.

Version conflicts cause errors like:

> SyntaxError: Source file requires different compiler version (current compiler is 0.4.18+commit.9cf6e910.Emscripten.clang - note that nightly builds are considered to be strictly less than the released version
