### PR TITLE
require service and key creator to own healthcash

### DIFF
--- a/contracts/HealthDRS.sol
+++ b/contracts/HealthDRS.sol
@@ -249,6 +249,7 @@ contract HealthDRS is Ownable {
        public
        ownsKey(key)
        canShare(key)
+       holdingTokens()       
    {
        if (isKeyOwner(key, account) == false) {
            owners[key].push(account);
@@ -267,6 +268,7 @@ contract HealthDRS is Ownable {
    function unshareKey(bytes32 key, address account)
        public
        ownsKey(key)
+       holdingTokens()       
    {
        for (uint i = 0; i < owners[key].length; i++) {
            if (owners[key][i] == account) {

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,23 +1,23 @@
 pragma solidity ^0.4.2;
 
 contract Migrations {
-  address public owner;
-  uint public last_completed_migration;
+    address public owner;
+    uint public last_completed_migration;
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
-  }
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
 
-  function Migrations() {
-    owner = msg.sender;
-  }
+    function Migrations() public {
+        owner = msg.sender;
+    }
 
-  function setCompleted(uint completed) restricted {
-    last_completed_migration = completed;
-  }
+    function setCompleted(uint completed) restricted {
+        last_completed_migration = completed;
+    }
 
-  function upgrade(address new_address) restricted {
-    Migrations upgraded = Migrations(new_address);
-    upgraded.setCompleted(last_completed_migration);
-  }
+    function upgrade(address new_address) restricted {
+        Migrations upgraded = Migrations(new_address);
+        upgraded.setCompleted(last_completed_migration);
+    }
 }

--- a/test/HealthDRS-Admin.js
+++ b/test/HealthDRS-Admin.js
@@ -52,4 +52,23 @@ contract('HealthDRS :: Admin', function(accounts) {
     secondAddress.should.not.equal(accounts[1])  
   })
 
+  it('minimum hold should be updateable by admin', async function() {
+    let minimumHold = await this.drs.minimumHold()
+    await this.drs.setMinimumHold(5000)
+    let newMinimumHold = await this.drs.minimumHold()
+
+    newMinimumHold.should.be.bignumber.not.equal(minimumHold)  
+    newMinimumHold.should.be.bignumber.equal(5000)  
+  })
+
+  it('minimum hold should only be updateable by admin', async function() {
+    let minimumHold = await this.drs.minimumHold()
+    await this.drs.setMinimumHold(5000,{from: accounts[1]})    
+    let newMinimumHold = await this.drs.minimumHold()
+
+    newMinimumHold.should.be.bignumber.equal(minimumHold)  
+    newMinimumHold.should.be.bignumber.not.equal(5000)  
+  })
+
+
 })

--- a/test/HealthDRS.js
+++ b/test/HealthDRS.js
@@ -24,6 +24,20 @@ contract('HealthDRS', function(accounts) {
     owner.should.equal(true);    
   })
  
+  it('non holder should not be able to create a service', async function() {
+    let tx = await this.drs.createService(this.url,{from: accounts[1]})
+    tx.logs.length.should.equal(0);    
+  })
+
+  it('non holder should be able to create a service after procuring health cash', async function() {
+    let min = await this.drs.minimumHold()
+    await this.token.transfer(accounts[1],min.toNumber())
+    let tx = await this.drs.createService(this.url,{from: accounts[1]})
+    let service = tx.logs[0].args._service
+    let owner = await this.drs.isServiceOwner(service, accounts[1])
+    owner.should.equal(true);    
+  })
+
   it('should return the correct URL when passed a service key', async function() {
     let tx = await this.drs.createService(this.url)
     let service = tx.logs[0].args._service
@@ -81,6 +95,5 @@ contract('HealthDRS', function(accounts) {
     let url = await this.drs.getUrlFromKey(key2) 
     url.should.equal('changedUrl')    
   })
-
 
 })

--- a/test/helpers/HealthCashMock.sol
+++ b/test/helpers/HealthCashMock.sol
@@ -7,7 +7,7 @@ contract HealthCashMock is StandardToken {
   string public name = "Health Cash";
   string public symbol = "HLTH";
   uint256 public decimals = 18;
-  uint256 public INITIAL_SUPPLY = 100;
+  uint256 public INITIAL_SUPPLY = 100000000;
 
   function HealthCashMock() {
     totalSupply = INITIAL_SUPPLY;

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -4,7 +4,7 @@ module.exports = {
     development: {
       host: "localhost",
       port: 8545,
-      network_id: "*" // Match any network id
+      network_id: "*"
     }
   }
 };

--- a/truffle.js
+++ b/truffle.js
@@ -7,7 +7,7 @@ module.exports = {
     development: {
       host: "localhost",
       port: 8545,
-      network_id: "*" // Match any network id
+      network_id: "*"   
     }
   }
 };


### PR DESCRIPTION
The creates a new variable minimumHold which defines how much health cash a service and key creator must own before they can create a service or key. Those attempting to create a service or key without the minimumHold amount of health cash will be prevented from doing so. 