### PR TITLE
package.json to refect the compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "truffle-contract": "^2.0.5"
   },
   "dependencies": {
-    "zeppelin-solidity": "^1.2.0"
+    "zeppelin-solidity": "~1.2.0"
   }
 }


### PR DESCRIPTION
Limits zeppelin-solidity's versions which work with this version.

Temporary fix for #8